### PR TITLE
upgrade to elasticsearch 7

### DIFF
--- a/.devcontainer/Aptfile
+++ b/.devcontainer/Aptfile
@@ -1,4 +1,6 @@
 # development only package dependencies
 build-essential
+curl
+jq
 git
 vim

--- a/.devcontainer/Dockerfile
+++ b/.devcontainer/Dockerfile
@@ -4,7 +4,7 @@ ARG DISTRO_NAME=buster
 
 FROM ruby:$RUBY_VERSION-slim-$DISTRO_NAME
 
-LABEL maintainer="support@kerkdienstgemist.nl"
+LABEL maintainer="k.j.wierenga@kerkdienstgemist.nl"
 
 # Install dependencies specified in Aptfile
 COPY Aptfile /tmp/

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -1,5 +1,7 @@
 ## Release 0.2.0
+
 Merge branch 'feature/fix/hashie-warnings' into develop
+
 - [fix] pin faraday to a compatible version
 - [enh] upgrade to ruby 2.4(.6)
 - [fix] suppress Hashie warnings; it would generate a warning for each log line (on stdout) leading to very large output
@@ -8,32 +10,32 @@ Merge branch 'feature/fix/hashie-warnings' into develop
 
 Enhancements
 
-* Change default time steps from 1 hour to 120 seconds to aid in grepping from datasets with many events per minute.
+- Change default time steps from 1 hour to 120 seconds to aid in grepping from datasets with many events per minute.
 
 ### 0.1.3 / 2015-05-28
 
 Enhancements
 
-* Remove troublesome development dependencies (autotest).
+- Remove troublesome development dependencies (autotest).
 
 ### 0.1.2 / 2015-01-02
 
 Enhancements
 
-* Double Elasticsearch::Client request timeout to 120 seconds to prevent Timeout::Error (Faraday::TimeoutError).
+- Double Elasticsearch::Client request timeout to 120 seconds to prevent Timeout::Error (Faraday::TimeoutError).
 
 ### 0.1.1 / 2014-10-13
 
 Enhancements
 
-* Refactor to iterate over hour periods instead of full indices. This improves the performance a lot.
-* Increase timeout to prevent Faraday::TimeoutError exceptions.
+- Refactor to iterate over hour periods instead of full indices. This improves the performance a lot.
+- Increase timeout to prevent Faraday::TimeoutError exceptions.
 
 ### 0.0.9 / 2014-09-22
 
 Enhancements
 
-* We only every print the 'message' field. To optimize we only query for the 'message' field
+- We only every print the 'message' field. To optimize we only query for the 'message' field
   to be returned in the results. This should cut down the size of the returned json documents
   which could potentially be (very) large.
 
@@ -41,47 +43,47 @@ Enhancements
 
 Bug Fixes
 
-* Require missing 'uri' (instead of using typhoed or patron HTTP transport clients).
+- Require missing 'uri' (instead of using typhoed or patron HTTP transport clients).
 
 ### 0.0.7 / 2014-09-01
 
 Bug Fixes
 
-* Use Typhoed transport instead of Patron. The C-extension of Patron doesn't play nice with JRuby.
+- Use Typhoed transport instead of Patron. The C-extension of Patron doesn't play nice with JRuby.
 
 ### 0.0.6 / 2014-09-01
 
 Bug Fixes
 
-* Pushing version 0.0.5 failed and it was yanked from rubygems.org. Need to push new version 0.0.6.
+- Pushing version 0.0.5 failed and it was yanked from rubygems.org. Need to push new version 0.0.6.
 
 ### 0.0.5 / 2014-09-01
 
 Bug Fixes
 
-* Running as binary didn't load HTTP client properly. Add 'patron' dependency
+- Running as binary didn't load HTTP client properly. Add 'patron' dependency
   to force loading an appropriate HTTP client.
 
 ### 0.0.4 / 2014-08-29
 
 Bug Fixes
 
-* Use .ruby-[version|gemset] to support any ruby environment manager.
+- Use .ruby-[version|gemset] to support any ruby environment manager.
 
 ### 0.0.3 / 2014-08-28
 
 Bug Fixes
 
-* Run CI on travis-ci.org.
-* Fixate timezone to assumed timezone for specs.
-* Run Ruby 2.1.1 instead of 2.1.0.
+- Run CI on travis-ci.org.
+- Fixate timezone to assumed timezone for specs.
+- Run Ruby 2.1.1 instead of 2.1.0.
 
 ### 0.0.2 / 2014-08-28
 
 Enhancements
 
-* Updated documentation.
-* Rename debug option (-v) to (-d).
+- Updated documentation.
+- Rename debug option (-v) to (-d).
 
 ### 0.0.1 / 2014-08-28
 

--- a/README.md
+++ b/README.md
@@ -153,7 +153,7 @@ Grep example
 
 1. Build the gem
 
-        $ gem build lstash.gem
+        $ gem build lstash
         Successfully built RubyGem
         Name: lstash
         Version: 0.2.0

--- a/README.md
+++ b/README.md
@@ -130,20 +130,20 @@ Usage:
 
     bundle console
 
-# connect to elasticsearch and create the Lstash client
+Connect to elasticsearch and create the Lstash client
 
     elasticsearch = Elasticsearch::Client.new(url: ENV['ES_URL'])
     client = Lstash::Client.new(elasticsearch, debug: true)
 
-# create the query
+Create the query
 
     query = Lstash::Query.new('program:haproxy', from: 'today', to: 'now')
 
-# count
+Count example
 
     client.count(query)
 
-# grep
+Grep example
 
     client.grep(query) do |message|
       puts message

--- a/README.md
+++ b/README.md
@@ -132,8 +132,8 @@ Usage:
 
 # connect to elasticsearch and create the Lstash client
 
-    elasticsearch = Elasticsearch::Client.new(url: 'log.mydomain.com')
-    client = Lstash::Client.new(elasticsearch)
+    elasticsearch = Elasticsearch::Client.new(url: ENV['ES_URL'])
+    client = Lstash::Client.new(elasticsearch, debug: true)
 
 # create the query
 

--- a/README.md
+++ b/README.md
@@ -8,48 +8,48 @@ Lstash is a gem and command line utility to count or grep log messages in a cert
 
 Or install it yourself as:
 
-    $ gem install lstash
+    gem install lstash
 
 ## Running lstash from the command line
 
-	$ lstash
-	Commands:
-	  lstash count QUERY     # count number of log messages matching the QUERY
-	  lstash grep QUERY      # grep log messages from Logstash
-	  lstash help [COMMAND]  # Describe available commands or one specific command
+    $ lstash
+    Commands:
+      lstash count QUERY     # count number of log messages matching the QUERY
+      lstash grep QUERY      # grep log messages from Logstash
+      lstash help [COMMAND]  # Describe available commands or one specific command
 
 ## The `count` command
 
-	Usage:
-	  lstash count QUERY
+    Usage:
+      lstash count QUERY
 
-	Description:
-	  Count log messages matching the QUERY from Logstash and output this count to stdout. QUERY can use Apache Lucene query
-	  parser syntax.
+     Description:
+       Count log messages matching the QUERY from Logstash and output this count to stdout. QUERY can use Apache Lucene query
+       parser syntax.
 
-	  Example to count the number of HAProxy log messages in yesterdays month.
+       Example to count the number of HAProxy log messages in yesterdays month.
 
-	  lstash count 'program:haproxy' --from firstday --to today --anchor yesterday
+       lstash count 'program:haproxy' --from firstday --to today --anchor yesterday
 
 ## The `grep` command
 
-	Usage:
-	  lstash grep QUERY
+    Usage:
+      lstash grep QUERY
 
-	Description:
-	  Grep log messages matching the QUERY from Logstash in ascending timestamp order and output to stdout. QUERY can use Apache Lucene query parser syntax.
+    Description:
+      Grep log messages matching the QUERY from Logstash in ascending timestamp order and output to stdout. QUERY can use Apache    Lucene query parser syntax.
 
-	  Example to grep HAProxy log messages from the beginning of this month upto now
+      Example to grep HAProxy log messages from the beginning of this month upto now
 
-	  lstash grep 'program:haproxy' --from firstday --to now
+      lstash grep 'program:haproxy' --from firstday --to now
 
 ## Command line options
 
-	Options:
-	  -f, [--from=start of time range]                    # date/time, 'now', 'today', 'yesterday', or 'firstday'
-	  -t, [--to=end of time range]                        # date/time, 'now', 'today', 'yesterday', or 'firstday'
-	  -a, [--anchor=anchor date/time]                     # used as reference date for firstday
-	  -e, [--es-url=Elasticsearch endpoint for Logstash]  # or ES_URL environment variable
+    Options:
+      -f, [--from=start of time range]                    # date/time, 'now', 'today', 'yesterday', or 'firstday'
+      -t, [--to=end of time range]                        # date/time, 'now', 'today', 'yesterday', or 'firstday'
+      -a, [--anchor=anchor date/time]                     # used as reference date for firstday
+      -e, [--es-url=Elasticsearch endpoint for Logstash]  # or ES_URL environment variable
 
 All times will be relative to the timezone of the machine on which you are running lstash.
 
@@ -66,7 +66,7 @@ Example
 
 Or
 
-	lstash count program:haproxy --es-url log.mydomain.com
+    lstash count program:haproxy --es-url log.mydomain.com
 
 ## Examples
 
@@ -80,41 +80,41 @@ Grep all haproxy log messages using for one day (Aug 24 1 0:00 am upto and inclu
 
 Assuming today is Sep 1 2014. Count all haproxy log messages in the previous month.
 
-	lstash count program:haproxy --anchor yesterday --from firstday --to today -d
-	time range: [2014-08-01 00:00:00 +0200..2014-09-01 00:00:00 +0200]
-	logstash-2014.07.31: 1
-	logstash-2014.08.01: 13
-	logstash-2014.08.02: 14
-	logstash-2014.08.03: 1654
-	logstash-2014.08.04: 6
-	logstash-2014.08.05: 20
-	logstash-2014.08.06: 219
-	logstash-2014.08.07: 32
-	logstash-2014.08.08: 14
-	logstash-2014.08.09: 28
-	logstash-2014.08.10: 799
-	logstash-2014.08.11: 18
-	logstash-2014.08.12: 8
-	logstash-2014.08.13: 23
-	logstash-2014.08.14: 25
-	logstash-2014.08.15: 69
-	logstash-2014.08.16: 19
-	logstash-2014.08.17: 1160
-	logstash-2014.08.18: 284
-	logstash-2014.08.19: 61
-	logstash-2014.08.20: 26
-	logstash-2014.08.21: 16
-	logstash-2014.08.22: 145
-	logstash-2014.08.23: 72
-	logstash-2014.08.24: 792
-	logstash-2014.08.25: 31
-	logstash-2014.08.26: 33
-	logstash-2014.08.27: 51
-	logstash-2014.08.28: 8
-	logstash-2014.08.29: 23
-	logstash-2014.08.30: 25
-	logstash-2014.08.31: 69
-	5633
+    lstash count program:haproxy --anchor yesterday --from firstday --to today -d
+    time range: [2014-08-01 00:00:00 +0200..2014-09-01 00:00:00 +0200]
+    logstash-2014.07.31: 1
+    logstash-2014.08.01: 13
+    logstash-2014.08.02: 14
+    logstash-2014.08.03: 1654
+    logstash-2014.08.04: 6
+    logstash-2014.08.05: 20
+    logstash-2014.08.06: 219
+    logstash-2014.08.07: 32
+    logstash-2014.08.08: 14
+    logstash-2014.08.09: 28
+    logstash-2014.08.10: 799
+    logstash-2014.08.11: 18
+    logstash-2014.08.12: 8
+    logstash-2014.08.13: 23
+    logstash-2014.08.14: 25
+    logstash-2014.08.15: 69
+    logstash-2014.08.16: 19
+    logstash-2014.08.17: 1160
+    logstash-2014.08.18: 284
+    logstash-2014.08.19: 61
+    logstash-2014.08.20: 26
+    logstash-2014.08.21: 16
+    logstash-2014.08.22: 145
+    logstash-2014.08.23: 72
+    logstash-2014.08.24: 792
+    logstash-2014.08.25: 31
+    logstash-2014.08.26: 33
+    logstash-2014.08.27: 51
+    logstash-2014.08.28: 8
+    logstash-2014.08.29: 23
+    logstash-2014.08.30: 25
+    logstash-2014.08.31: 69
+    5633
 
 ## Using lstash as a gem in your project
 
@@ -124,46 +124,46 @@ Add this line to your application's Gemfile:
 
 And then execute:
 
-    $ bundle
+    bundle
 
 Usage:
 
-	$ bundle console
+    bundle console
 
-	# connect to elasticsearch and create the Lstash client
-	elasticsearch = Elasticsearch::Client.new(url: 'log.mydomain.com')
-	client = Lstash::Client.new(elasticsearch)
+# connect to elasticsearch and create the Lstash client
 
-	# create the query
-	query = Lstash::Query.new('program:haproxy', from: 'today', to: 'now')
+    elasticsearch = Elasticsearch::Client.new(url: 'log.mydomain.com')
+    client = Lstash::Client.new(elasticsearch)
 
-	# count
-	client.count(query)
+# create the query
 
-	# grep
-	client.grep(query) do |message|
-	  puts message
-	end
+    query = Lstash::Query.new('program:haproxy', from: 'today', to: 'now')
+
+# count
+
+    client.count(query)
+
+# grep
+
+    client.grep(query) do |message|
+      puts message
+    end
 
 ## Publishing the gem to RubyGems.org
 
 1. Build the gem
 
-```
-$ gem build lstash.gem
-  Successfully built RubyGem
-  Name: lstash
-  Version: 0.2.0
-  File: lstash-0.2.0.gem
-```
+        $ gem build lstash.gem
+        Successfully built RubyGem
+        Name: lstash
+        Version: 0.2.0
+        File: lstash-0.2.0.gem
 
 2. Pushing your gem to RubyGems.org
 
-```
-gem push lstash-0.2.0.gem
-  Pushing gem to RubyGems.org...
-  Successfully registered gem: lstash (0.2.0)
-```
+        $ gem push lstash-0.2.0.gem
+        Pushing gem to RubyGems.org...
+        Successfully registered gem: lstash (0.2.0)
 
 See [RubyGems.org documention](https://guides.rubygems.org/) for more info.
 

--- a/README.md
+++ b/README.md
@@ -1,6 +1,6 @@
 # lstash
 
-[![Build Status](https://travis-ci.org/kjwierenga/lstash.svg?branch=master)](https://travis-ci.org/kjwierenga/lstash)
+[![Run tests](https://github.com/kdgm/lstash/actions/workflows/test.yml/badge.svg)](https://github.com/kdgm/lstash/actions/workflows/test.yml)
 
 Lstash is a gem and command line utility to count or grep log messages in a certain time frame from a Logstash Elasticsearch server.
 

--- a/bin/lstash
+++ b/bin/lstash
@@ -1,7 +1,5 @@
 #!/usr/bin/env ruby
 
-require 'lstash/cli'
+require "lstash/cli"
 
-# Suppress Hashie warnings
-Hashie.logger = Logger.new(nil)
 Lstash::CLI.start(ARGV)

--- a/docker-compose.yml
+++ b/docker-compose.yml
@@ -16,6 +16,7 @@ x-base: &base
     HISTFILE: /usr/local/hist/.bash_history
     IRB_HISTFILE: /usr/local/hist/.irb_history
     EDITOR: ${EDITOR:-vi}
+    ES_URL: http://host.docker.internal:9200
 
 services:
   runner:

--- a/lib/lstash.rb
+++ b/lib/lstash.rb
@@ -1,7 +1,7 @@
-require 'elasticsearch'
-require 'lstash/version'
-require 'lstash/query'
-require 'lstash/client'
+require "elasticsearch"
+require "lstash/version"
+require "lstash/query"
+require "lstash/client"
 
 module Lstash
   # Your code goes here...

--- a/lib/lstash/cli.rb
+++ b/lib/lstash/cli.rb
@@ -70,7 +70,7 @@ module Lstash
 
     def run_command(query_string)
       es_client = ::Elasticsearch::Client.new(
-        url: options[:es_url] || ENV["ES_URL"] || "localhost",
+        url: options[:es_url] || ENV["ES_URL"] || "http://localhost:9200",
         log: ENV["DEBUG"] == "true",
         transport_options: {request: {timeout: TRANSPORT_REQUEST_TIMEOUT}}
       )

--- a/lib/lstash/cli.rb
+++ b/lib/lstash/cli.rb
@@ -55,7 +55,7 @@ module Lstash
     def run_command(query_string)
       es_client = ::Elasticsearch::Client.new(
         url: options[:es_url] || ENV["ES_URL"] || "localhost",
-        log: !!ENV["DEBUG"],
+        log: ENV["DEBUG"] == "true",
         transport_options: {request: {timeout: TRANSPORT_REQUEST_TIMEOUT}}
       )
       query = Lstash::Query.new(query_string, options)

--- a/lib/lstash/cli.rb
+++ b/lib/lstash/cli.rb
@@ -6,6 +6,7 @@ require "elasticsearch"
 # local files we need
 require "lstash/query"
 require "lstash/client"
+require "lstash/version"
 
 module Lstash
   TRANSPORT_REQUEST_TIMEOUT = 120 # 2 minute request timeout

--- a/lib/lstash/cli.rb
+++ b/lib/lstash/cli.rb
@@ -15,8 +15,8 @@ module Lstash
     class << self
       def shared_options
         method_option :anchor, banner: "YYYY-mm-dd", aliases: "-a", desc: "The 'firstday' is relative to this anchor date", default: "today"
-        method_option :from, banner: "YYYY-mm-dd [HH:MM:SS]", aliases: "-f", desc: "Start date/time, 'now', 'today', 'yesterday', or 'firstday'", default: "today"
-        method_option :to, banner: "YYYY-mm-dd [HH:MM:SS]", aliases: "-t", desc: "End date/time, 'now', 'today', 'yesterday', or 'firstday'", default: "now"
+        method_option :from, banner: "YYYY-mm-dd [HH:MM:SS]", aliases: "-f", desc: "Start date/time, 'now', 'today', 'yesterday', or 'firstday'", default: "yesterday"
+        method_option :to, banner: "YYYY-mm-dd [HH:MM:SS]", aliases: "-t", desc: "End date/time, 'now', 'today', 'yesterday', or 'firstday'", default: "today"
         method_option :es_url, banner: "http://localhost:9200", aliases: "-e", desc: "Elasticsearch URL or set ES_URL environment variable"
         method_option :debug, desc: "Log debugging info to stderr", aliases: "-d", type: :boolean, default: false
         method_option :wildcard, desc: "Use index wildcard to query all logstash-* indices (fast for count, slow for grep)", type: :boolean

--- a/lib/lstash/cli.rb
+++ b/lib/lstash/cli.rb
@@ -19,7 +19,7 @@ module Lstash
         method_option :to, banner: "YYYY-mm-dd [HH:MM:SS]", aliases: "-t", desc: "End date/time, 'now', 'today', 'yesterday', or 'firstday'", default: "now"
         method_option :es_url, banner: "http://localhost:9200", aliases: "-e", desc: "Elasticsearch URL or set ES_URL environment variable"
         method_option :debug, desc: "Log debugging info to stderr", aliases: "-d", type: :boolean, default: false
-        method_option :fast, desc: "Use wildcard to query all logstash-* indices", type: :boolean, default: false
+        method_option :wildcard, desc: "Use index wildcard to query all logstash-* indices (fast for count, slow for grep)", type: :boolean
       end
     end
   end

--- a/lib/lstash/cli.rb
+++ b/lib/lstash/cli.rb
@@ -14,12 +14,12 @@ module Lstash
   class CLIBase < Thor
     class << self
       def shared_options
-        method_option :from, banner: "start of time range", aliases: "-f", desc: "date/time, 'now', 'today', 'yesterday', or 'firstday'"
-        method_option :to, banner: "end of time range", aliases: "-t", desc: "date/time, 'now', 'today', 'yesterday', or 'firstday'"
-        method_option :anchor, banner: "anchor date/time", aliases: "-a", desc: "used as reference date for firstday"
-        method_option :es_url, banner: "Elasticsearch endpoint for Logstash", aliases: "-e", desc: "or ES_URL environment variable"
-        method_option :debug, banner: "debug log to stderr", aliases: "-d", type: :boolean
-        method_option :fast, desc: "user wildcard to query all logstash-* indices", type: :boolean, default: false
+        method_option :anchor, banner: "YYYY-mm-dd", aliases: "-a", desc: "The 'firstday' is relative to this anchor date", default: "today"
+        method_option :from, banner: "YYYY-mm-dd [HH:MM:SS]", aliases: "-f", desc: "Start date/time, 'now', 'today', 'yesterday', or 'firstday'", default: "today"
+        method_option :to, banner: "YYYY-mm-dd [HH:MM:SS]", aliases: "-t", desc: "End date/time, 'now', 'today', 'yesterday', or 'firstday'", default: "now"
+        method_option :es_url, banner: "http://localhost:9200", aliases: "-e", desc: "Elasticsearch URL or set ES_URL environment variable"
+        method_option :debug, desc: "Log debugging info to stderr", aliases: "-d", type: :boolean, default: false
+        method_option :fast, desc: "Use wildcard to query all logstash-* indices", type: :boolean, default: false
       end
     end
   end

--- a/lib/lstash/cli.rb
+++ b/lib/lstash/cli.rb
@@ -1,23 +1,21 @@
 # external dependencies
-require 'thor'
-require 'uri'
-require 'elasticsearch'
+require "thor"
+require "uri"
+require "elasticsearch"
 
 # local files we need
-require 'lstash/query'
-require 'lstash/client'
+require "lstash/query"
+require "lstash/client"
 
 module Lstash
-
-  TRANSPORT_REQUEST_TIMEOUT = 120.freeze # 2 minute request timeout
+  TRANSPORT_REQUEST_TIMEOUT = 120 # 2 minute request timeout
 
   class CLI < Thor
-
-    class_option :from,   :banner => 'start of time range', :aliases => '-f', :desc => "date/time, 'now', 'today', 'yesterday', or 'firstday'"
-    class_option :to,     :banner => 'end of time range',   :aliases => '-t', :desc => "date/time, 'now', 'today', 'yesterday', or 'firstday'"
-    class_option :anchor, :banner => 'anchor date/time',    :aliases => '-a', :desc => "used as reference date for firstday"
-    class_option :es_url, :banner => 'Elasticsearch endpoint for Logstash', :aliases => '-e', :desc => "or ES_URL environment variable"
-    class_option :debug,  :banner => 'debug log to stderr', :aliases => '-d', :type => :boolean
+    class_option :from, banner: "start of time range", aliases: "-f", desc: "date/time, 'now', 'today', 'yesterday', or 'firstday'"
+    class_option :to, banner: "end of time range", aliases: "-t", desc: "date/time, 'now', 'today', 'yesterday', or 'firstday'"
+    class_option :anchor, banner: "anchor date/time", aliases: "-a", desc: "used as reference date for firstday"
+    class_option :es_url, banner: "Elasticsearch endpoint for Logstash", aliases: "-e", desc: "or ES_URL environment variable"
+    class_option :debug, banner: "debug log to stderr", aliases: "-d", type: :boolean
 
     long_desc <<-LONGDESC
       Grep log messages matching the QUERY from Logstash in ascending timestamp order
@@ -56,25 +54,24 @@ module Lstash
 
     def run_command(query_string)
       es_client = ::Elasticsearch::Client.new(
-        url: options[:es_url] || ENV['ES_URL'] || 'localhost',
-        log: !!ENV['DEBUG'],
-        transport_options: { request: { timeout: TRANSPORT_REQUEST_TIMEOUT } }
+        url: options[:es_url] || ENV["ES_URL"] || "localhost",
+        log: !!ENV["DEBUG"],
+        transport_options: {request: {timeout: TRANSPORT_REQUEST_TIMEOUT}}
       )
-      query  = Lstash::Query.new(query_string, options)
+      query = Lstash::Query.new(query_string, options)
 
       yield es_client, query
-
-    rescue Exception => e
+    rescue => e
       options[:debug] ? raise(e) : raise(Thor::Error.new(e.message))
     end
 
-    protected
-
     # Make sure we exit on failure with an error code
-    def self.exit_on_failure?
-      true
+    class << self
+      protected
+
+      def exit_on_failure?
+        true
+      end
     end
-
   end
-
 end

--- a/lib/lstash/cli.rb
+++ b/lib/lstash/cli.rb
@@ -59,6 +59,12 @@ module Lstash
       end
     end
 
+    long_desc "Print the lstash version"
+    desc "version", "print lstash version"
+    def version
+      puts Lstash::VERSION
+    end
+
     private
 
     def run_command(query_string)

--- a/lib/lstash/cli.rb
+++ b/lib/lstash/cli.rb
@@ -16,6 +16,7 @@ module Lstash
     class_option :anchor, banner: "anchor date/time", aliases: "-a", desc: "used as reference date for firstday"
     class_option :es_url, banner: "Elasticsearch endpoint for Logstash", aliases: "-e", desc: "or ES_URL environment variable"
     class_option :debug, banner: "debug log to stderr", aliases: "-d", type: :boolean
+    class_option :fast, desc: "user wildcard to query all logstash-* indices", type: :boolean, default: false
 
     long_desc <<-LONGDESC
       Grep log messages matching the QUERY from Logstash in ascending timestamp order

--- a/lib/lstash/cli.rb
+++ b/lib/lstash/cli.rb
@@ -10,14 +10,20 @@ require "lstash/client"
 module Lstash
   TRANSPORT_REQUEST_TIMEOUT = 120 # 2 minute request timeout
 
-  class CLI < Thor
-    class_option :from, banner: "start of time range", aliases: "-f", desc: "date/time, 'now', 'today', 'yesterday', or 'firstday'"
-    class_option :to, banner: "end of time range", aliases: "-t", desc: "date/time, 'now', 'today', 'yesterday', or 'firstday'"
-    class_option :anchor, banner: "anchor date/time", aliases: "-a", desc: "used as reference date for firstday"
-    class_option :es_url, banner: "Elasticsearch endpoint for Logstash", aliases: "-e", desc: "or ES_URL environment variable"
-    class_option :debug, banner: "debug log to stderr", aliases: "-d", type: :boolean
-    class_option :fast, desc: "user wildcard to query all logstash-* indices", type: :boolean, default: false
+  class CLIBase < Thor
+    class << self
+      def shared_options
+        method_option :from, banner: "start of time range", aliases: "-f", desc: "date/time, 'now', 'today', 'yesterday', or 'firstday'"
+        method_option :to, banner: "end of time range", aliases: "-t", desc: "date/time, 'now', 'today', 'yesterday', or 'firstday'"
+        method_option :anchor, banner: "anchor date/time", aliases: "-a", desc: "used as reference date for firstday"
+        method_option :es_url, banner: "Elasticsearch endpoint for Logstash", aliases: "-e", desc: "or ES_URL environment variable"
+        method_option :debug, banner: "debug log to stderr", aliases: "-d", type: :boolean
+        method_option :fast, desc: "user wildcard to query all logstash-* indices", type: :boolean, default: false
+      end
+    end
+  end
 
+  class CLI < CLIBase
     long_desc <<-LONGDESC
       Grep log messages matching the QUERY from Logstash in ascending timestamp order
       and output to stdout. QUERY can use Apache Lucene query parser syntax.
@@ -26,7 +32,8 @@ module Lstash
 
         lstash grep 'program:haproxy' --from firstday --to now
     LONGDESC
-    desc "grep QUERY", "grep log messages from Logstash"
+    desc "grep QUERY", "Grep log messages from Logstash"
+    shared_options
     def grep(query_string)
       run_command(query_string) do |es_client, query|
         Lstash::Client.new(es_client, options).grep(query) do |message|
@@ -43,7 +50,8 @@ module Lstash
 
         lstash count 'program:haproxy' --from firstday --to today --anchor yesterday
     LONGDESC
-    desc "count QUERY", "count number of log messages matching the QUERY"
+    desc "count QUERY", "Count number of log messages matching the QUERY"
+    shared_options
     def count(query_string)
       run_command(query_string) do |es_client, query|
         count = Lstash::Client.new(es_client, options).count(query)

--- a/lib/lstash/client.rb
+++ b/lib/lstash/client.rb
@@ -70,7 +70,7 @@ module Lstash
     def count_messages(index, query)
       result = @es_client.count(index: index, body: {query: query.filter})
       validate_shards!(result["_shards"])
-      @logger.debug "count index=#{index} from=#{query.from} to=#{query.to} count=#{result["count"]}"
+      @logger.debug "count index=#{index} from=#{query.from} to=#{query.to.utc} count=#{result["count"]}"
       result["count"]
     end
 

--- a/lib/lstash/client.rb
+++ b/lib/lstash/client.rb
@@ -16,8 +16,8 @@ module Lstash
     class ShardMismatchError < StandardError; end
 
     PER_PAGE = 5000 # best time, lowest resource usage
-    DEFAULT_COUNT_STEP = 3600 # 1 hour
-    DEFAULT_GREP_STEP = 3600 # 1 hour # 120  # 2 minutes
+    COUNT_STEP = 3600 # 1 hours
+    GREP_STEP = 3600 # 1 hour
 
     def initialize(es_client, options = {})
       raise ConnectionError, "No elasticsearch client specified" if es_client.nil?
@@ -26,22 +26,22 @@ module Lstash
       @logger = options[:logger] || (options[:debug] ? debug_logger : NullLogger.new)
     end
 
-    def count(query, step = DEFAULT_COUNT_STEP)
+    def count(query)
       @logger.debug "count from=#{query.from} to=#{query.to}"
 
       count = 0
-      query.each_period(step) do |index, hour_query|
+      query.each_period(COUNT_STEP) do |index, hour_query|
         count += count_messages(index, hour_query)
       end
       @logger.debug "total count=#{count}"
       count
     end
 
-    def grep(query, step = DEFAULT_GREP_STEP)
+    def grep(query)
       @logger.debug "grep from=#{query.from} to=#{query.to}"
 
       count = 0
-      query.each_period(step) do |index, hour_query|
+      query.each_period(GREP_STEP) do |index, hour_query|
         grep_messages(index, hour_query) do |message|
           count += 1
           yield message if block_given?

--- a/lib/lstash/client.rb
+++ b/lib/lstash/client.rb
@@ -70,7 +70,7 @@ module Lstash
         result = @es_client.send(method, {
           index: index,
           scroll: "5m",
-          body: query.search(offset, PER_PAGE)
+          body: (method == :search) ? query.search(offset, PER_PAGE) : nil
         }.merge(scroll_params))
 
         validate_shards!(result["_shards"])

--- a/lib/lstash/client.rb
+++ b/lib/lstash/client.rb
@@ -70,8 +70,8 @@ module Lstash
         result = @es_client.send(method, {
           index: index,
           scroll: "5m",
-          body: (method == :search) ? query.search(offset, PER_PAGE) : nil
-        }.merge(scroll_params))
+          body: (method == :search) ? query.search(offset, PER_PAGE) : scroll_params
+        })
 
         validate_shards!(result["_shards"])
 
@@ -87,7 +87,7 @@ module Lstash
         method = :scroll
       end
       @logger.debug "grep index=#{index} from=#{query.from} to=#{query.to} count=#{offset}"
-      @es_client.clear_scroll(scroll_params) unless scroll_params.empty?
+      @es_client.clear_scroll(body: scroll_params) unless scroll_params.empty?
     end
 
     def debug_logger

--- a/lib/lstash/client.rb
+++ b/lib/lstash/client.rb
@@ -17,7 +17,7 @@ module Lstash
 
     PER_PAGE = 5000 # best time, lowest resource usage
     DEFAULT_COUNT_STEP = 3600 # 1 hour
-    DEFAULT_GREP_STEP = 120  # 2 minutes
+    DEFAULT_GREP_STEP = 3600 # 1 hour # 120  # 2 minutes
 
     def initialize(es_client, options = {})
       raise ConnectionError, "No elasticsearch client specified" if es_client.nil?

--- a/lib/lstash/client.rb
+++ b/lib/lstash/client.rb
@@ -98,8 +98,9 @@ module Lstash
         end
 
         method = :scroll
+
+        @logger.debug "grep index=#{index} from=#{query.from} to=#{query.to.utc} count=#{offset}"
       end
-      @logger.debug "grep index=#{index} from=#{query.from} to=#{query.to} count=#{offset}"
       @es_client.clear_scroll(body: scroll_params) unless scroll_params.empty?
     end
 

--- a/lib/lstash/client.rb
+++ b/lib/lstash/client.rb
@@ -72,7 +72,7 @@ module Lstash
     def count_messages(index, query)
       result = @es_client.count(index: index, body: {query: query.filter})
       validate_shards!(result["_shards"])
-      @logger.debug "count index=#{index} from=#{query.from} to=#{query.to.utc} count=#{result["count"]}"
+      @logger.debug "count index=#{index} from=#{query.from.utc} to=#{query.to.utc} count=#{result["count"]}"
       result["count"]
     end
 
@@ -101,7 +101,7 @@ module Lstash
 
         method = :scroll
 
-        @logger.debug "grep index=#{index} from=#{query.from} to=#{query.to.utc} count=#{offset}"
+        @logger.debug "grep index=#{index} from=#{query.from.utc} to=#{query.to.utc} count=#{offset}"
       end
       @es_client.clear_scroll(body: scroll_params) unless scroll_params.empty?
     end

--- a/lib/lstash/client.rb
+++ b/lib/lstash/client.rb
@@ -1,27 +1,28 @@
-require 'logger'
-require 'date'
-require 'hashie'
+require "logger"
+require "date"
+require "hashie"
 
 class NullLogger < Logger
-  def initialize(*args); end
-  def add(*args, &block); end
+  def initialize(*args)
+  end
+
+  def add(*args, &block)
+  end
 end
 
 module Lstash
-
   class Client
-
     class ConnectionError < StandardError; end
 
-    PER_PAGE = 5000.freeze # best time, lowest resource usage
-    DEFAULT_COUNT_STEP = 3600.freeze # 1 hour
-    DEFAULT_GREP_STEP  = 120.freeze  # 2 minutes
+    PER_PAGE = 5000 # best time, lowest resource usage
+    DEFAULT_COUNT_STEP = 3600 # 1 hour
+    DEFAULT_GREP_STEP = 120  # 2 minutes
 
     def initialize(es_client, options = {})
       raise ConnectionError, "No elasticsearch client specified" if es_client.nil?
 
       @es_client = es_client
-      @logger    = options[:logger] || (options[:debug] ? debug_logger : NullLogger.new)
+      @logger = options[:logger] || (options[:debug] ? debug_logger : NullLogger.new)
     end
 
     def count(query, step = DEFAULT_COUNT_STEP)
@@ -55,10 +56,9 @@ module Lstash
     def count_messages(index, query)
       result = Hashie::Mash.new @es_client.send(:count,
         index: index,
-        body:  query.filter
-      )
-      @logger.debug "count index=#{index} from=#{query.from} to=#{query.to} count=#{result['count']}"
-      result['count']
+        body: query.filter)
+      @logger.debug "count index=#{index} from=#{query.from} to=#{query.to} count=#{result["count"]}"
+      result["count"]
     end
 
     def grep_messages(index, query)
@@ -66,11 +66,11 @@ module Lstash
       scroll_params = {}
       offset = 0
       method = :search
-      while (messages.nil? || messages.count > 0) do
+      while messages.nil? || messages.count > 0
         result = Hashie::Mash.new @es_client.send(method, {
-          index:  index,
-          scroll: '5m',
-          body:   query.search(offset, PER_PAGE),
+          index: index,
+          scroll: "5m",
+          body: query.search(offset, PER_PAGE)
         }.merge(scroll_params))
 
         messages = result.hits.hits
@@ -90,13 +90,11 @@ module Lstash
     end
 
     def debug_logger
-      logger = Logger.new(STDERR)
+      logger = Logger.new($stderr)
       logger.formatter = proc do |severity, datetime, progname, msg|
         "#{datetime} #{msg}\n"
       end
       logger
     end
-
   end
-
 end

--- a/lib/lstash/client.rb
+++ b/lib/lstash/client.rb
@@ -56,7 +56,7 @@ module Lstash
     def count_messages(index, query)
       result = Hashie::Mash.new @es_client.send(:count,
         index: index,
-        body: query.filter)
+        body: {query: query.filter})
       @logger.debug "count index=#{index} from=#{query.from} to=#{query.to} count=#{result["count"]}"
       result["count"]
     end

--- a/lib/lstash/query.rb
+++ b/lib/lstash/query.rb
@@ -27,6 +27,10 @@ module Lstash
       "#{LOGSTASH_PREFIX}#{date.strftime("%Y.%m.%d")}"
     end
 
+    def all_indices
+      "logstash-*"
+    end
+
     def search(from, size)
       {
         sort: sort_order,

--- a/lib/lstash/query.rb
+++ b/lib/lstash/query.rb
@@ -30,7 +30,7 @@ module Lstash
     def search(from, size)
       {
         sort: sort_order,
-        fields: %w[message],
+        _source: %w[message],
         query: filter,
         from: from,
         size: size
@@ -39,8 +39,8 @@ module Lstash
 
     def filter
       {
-        filtered: {
-          query: es_query,
+        bool: {
+          must: es_query,
           filter: es_filter
         }
       }
@@ -105,55 +105,22 @@ module Lstash
     end
 
     def es_query
-      {
-        bool: {
-          should: [
-            {
-              query_string: {
-                query: query_string
-              }
-            }
-          ]
+      [
+        {
+          query_string: {
+            query: query_string
+          }
         }
-      }
+      ]
     end
 
     def es_filter
       {
-        bool: {
-          must: [
-            range: {
-              "@timestamp" => {
-                gte: to_msec(from),
-                lt: to_msec(to)
-              }
-            }
-            # fquery: {
-            #   query: {
-            #     query_string: {
-            #       query: query_string
-            #     }
-            #   }
-            # }
-          ]
-          # must_not: [
-          #   fquery: {
-          #     query: {
-          #       query_string: {
-          #         query: query_string
-          #       }
-          #     }
-          #   }
-          # ],
-          # should: [
-          #   fquery: {
-          #     query: {
-          #       query_string: {
-          #         query: query_string
-          #       }
-          #     }
-          #   }
-          # ]
+        range: {
+          "@timestamp" => {
+            gte: to_msec(from),
+            lt: to_msec(to)
+          }
         }
       }
     end

--- a/lib/lstash/query.rb
+++ b/lib/lstash/query.rb
@@ -17,8 +17,8 @@ module Lstash
       @query_string = query_string
 
       @anchor = time_parse(arguments[:anchor], "today")
-      @from = time_parse(arguments[:from], "today")
-      @to = time_parse(arguments[:to], "now")
+      @from = time_parse(arguments[:from], "yesterday")
+      @to = time_parse(arguments[:to], "today")
 
       @to = Time.now if @to > Time.now # prevent accessing non-existing times / indices
     end

--- a/lib/lstash/query.rb
+++ b/lib/lstash/query.rb
@@ -64,9 +64,10 @@ module Lstash
     private
 
     def time_iterate(start_time, end_time, step, &block)
-      begin
+      while start_time < end_time
         yield(start_time)
-      end while (start_time += step) < end_time
+        start_time += step
+      end
     end
 
     def time_parse(time_or_string, default)

--- a/lib/lstash/query.rb
+++ b/lib/lstash/query.rb
@@ -27,7 +27,7 @@ module Lstash
       "#{LOGSTASH_PREFIX}#{date.strftime("%Y.%m.%d")}"
     end
 
-    def all_indices
+    def wildcard_indices
       "logstash-*"
     end
 

--- a/lib/lstash/version.rb
+++ b/lib/lstash/version.rb
@@ -1,3 +1,3 @@
 module Lstash
-  VERSION = "0.2.0"
+  VERSION = "1.0.0.pre"
 end

--- a/lstash.gemspec
+++ b/lstash.gemspec
@@ -24,7 +24,7 @@ Gem::Specification.new do |spec|
   spec.add_development_dependency "timecop", "~> 0.7.1"
 
   spec.add_dependency "typhoeus", "~> 1.4.0"
-  spec.add_dependency "elasticsearch", "~> 0.4"
+  spec.add_dependency "elasticsearch", "~> 7"
   spec.add_dependency "hashie", "~> 4.1.0"
   spec.add_dependency "thor", "~> 0.20.3"
   spec.add_dependency "faraday", "~> 0.17.4"

--- a/lstash.gemspec
+++ b/lstash.gemspec
@@ -1,23 +1,21 @@
-# coding: utf-8
-lib = File.expand_path('../lib', __FILE__)
+lib = File.expand_path("../lib", __FILE__)
 $LOAD_PATH.unshift(lib) unless $LOAD_PATH.include?(lib)
-require 'lstash/version'
+require "lstash/version"
 
 Gem::Specification.new do |spec|
-  spec.name          = "lstash"
-  spec.version       = Lstash::VERSION
-  spec.authors       = ["Klaas Jan Wierenga"]
-  spec.email         = ["k.j.wierenga@gmail.com"]
-  spec.description   = %q{Count or grep log messages in a specified time range from a Logstash Elasticsearch server.}
-  spec.summary       = %q{The lstash gem allows you to count or grep log messages in a specific time range from a Logstash Elasticsearch server. }
-  spec.homepage      = "https://github.com/kjwierenga/lstash"
-  spec.license       = "MIT"
+  spec.name = "lstash"
+  spec.version = Lstash::VERSION
+  spec.authors = ["Klaas Jan Wierenga"]
+  spec.email = ["k.j.wierenga@gmail.com"]
+  spec.description = "Count or grep log messages in a specified time range from a Logstash Elasticsearch server."
+  spec.summary = "The lstash gem allows you to count or grep log messages in a specific time range from a Logstash Elasticsearch server. "
+  spec.homepage = "https://github.com/kjwierenga/lstash"
+  spec.license = "MIT"
 
-  spec.files         = `git ls-files`.split($/)
-  spec.executables   = spec.files.grep(%r{^bin/}) { |f| File.basename(f) }
-  spec.test_files    = spec.files.grep(%r{^(test|spec|features)/})
+  spec.files = `git ls-files`.split($/)
+  spec.executables = spec.files.grep(%r{^bin/}) { |f| File.basename(f) }
   spec.require_paths = ["lib"]
-  spec.extra_rdoc_files = [ 'LICENSE.txt', 'README.md', 'CHANGELOG.md' ]
+  spec.extra_rdoc_files = ["LICENSE.txt", "README.md", "CHANGELOG.md"]
 
   spec.add_development_dependency "bundler", "~> 1.3"
   spec.add_development_dependency "rake", "~> 10.3.2"

--- a/lstash.gemspec
+++ b/lstash.gemspec
@@ -23,8 +23,6 @@ Gem::Specification.new do |spec|
   spec.add_development_dependency "rspec-its", "~> 1.0.1"
   spec.add_development_dependency "timecop", "~> 0.7.1"
 
-  spec.add_dependency "typhoeus", "~> 1.4.0"
   spec.add_dependency "elasticsearch", "~> 7"
   spec.add_dependency "thor", "~> 0.20.3"
-  spec.add_dependency "faraday", "~> 0.17.4"
 end

--- a/lstash.gemspec
+++ b/lstash.gemspec
@@ -9,7 +9,7 @@ Gem::Specification.new do |spec|
   spec.email = ["k.j.wierenga@gmail.com"]
   spec.description = "Count or grep log messages in a specified time range from a Logstash Elasticsearch server."
   spec.summary = "The lstash gem allows you to count or grep log messages in a specific time range from a Logstash Elasticsearch server. "
-  spec.homepage = "https://github.com/kjwierenga/lstash"
+  spec.homepage = "https://github.com/kdgm/lstash"
   spec.license = "MIT"
 
   spec.files = `git ls-files`.split($/)

--- a/lstash.gemspec
+++ b/lstash.gemspec
@@ -25,7 +25,6 @@ Gem::Specification.new do |spec|
 
   spec.add_dependency "typhoeus", "~> 1.4.0"
   spec.add_dependency "elasticsearch", "~> 7"
-  spec.add_dependency "hashie", "~> 4.1.0"
   spec.add_dependency "thor", "~> 0.20.3"
   spec.add_dependency "faraday", "~> 0.17.4"
 end

--- a/lstash.gemspec
+++ b/lstash.gemspec
@@ -23,6 +23,6 @@ Gem::Specification.new do |spec|
   spec.add_development_dependency "rspec-its", "~> 1.0.1"
   spec.add_development_dependency "timecop", "~> 0.7.1"
 
-  spec.add_dependency "elasticsearch", "~> 7"
+  spec.add_dependency "elasticsearch", "~> 7.17.7"
   spec.add_dependency "thor", "~> 0.20.3"
 end

--- a/lstash.gemspec
+++ b/lstash.gemspec
@@ -6,7 +6,7 @@ Gem::Specification.new do |spec|
   spec.name = "lstash"
   spec.version = Lstash::VERSION
   spec.authors = ["Klaas Jan Wierenga"]
-  spec.email = ["k.j.wierenga@gmail.com"]
+  spec.email = ["k.j.wierenga@kerkdienstgemist.nl"]
   spec.description = "Count or grep log messages in a specified time range from a Logstash Elasticsearch server."
   spec.summary = "The lstash gem allows you to count or grep log messages in a specific time range from a Logstash Elasticsearch server. "
   spec.homepage = "https://github.com/kdgm/lstash"

--- a/spec/lstash/cli_spec.rb
+++ b/spec/lstash/cli_spec.rb
@@ -1,5 +1,5 @@
-require 'spec_helper'
-require 'lstash/cli'
+require "spec_helper"
+require "lstash/cli"
 
 class Lstash::CLI < Thor
   def self.exit_on_failure?
@@ -8,9 +8,8 @@ class Lstash::CLI < Thor
 end
 
 describe Lstash::CLI do
-
   before(:all) do
-    Timecop.freeze('2014-08-01 14:58')
+    Timecop.freeze("2014-08-01 14:58")
   end
   after(:all) do
     Timecop.return
@@ -19,17 +18,16 @@ describe Lstash::CLI do
   context "options" do
     subject { Lstash::CLI.options(args) }
 
-    let(:args) { %w(extract --time from --to to --one --two --three --four) }
+    let(:args) { %w[extract --time from --to to --one --two --three --four] }
 
     its(:keys) { should eq args }
   end
 
   context "count" do
-
     context "with full URI" do
-      let(:args) { %w(count "*" --es-url http://localhost:9200) }
+      let(:args) { %w[count "*" --es-url http://localhost:9200] }
       it "should succeed" do
-        client = double('client')
+        client = double("client")
 
         allow(Lstash::Client).to receive(:new).and_return(client)
         allow(client).to receive(:count).and_return(1000)
@@ -42,10 +40,10 @@ describe Lstash::CLI do
     end
 
     context "with valid arguments" do
-      let(:args) { %w(count "program:haproxy" --es-url localhost) }
+      let(:args) { %w[count "program:haproxy" --es-url localhost] }
 
       it "should succeed" do
-        client = double('client')
+        client = double("client")
 
         allow(Lstash::Client).to receive(:new).and_return(client)
         allow(client).to receive(:count).and_return(100)
@@ -57,7 +55,7 @@ describe Lstash::CLI do
     end
 
     context "with invalid --es-url" do
-      let(:args) { %w(count "program:haproxy" --es-url '') }
+      let(:args) { %w[count "program:haproxy" --es-url ''] }
 
       it "should print error message" do
         output = capture_stderr { Lstash::CLI.start(args) }
@@ -67,7 +65,7 @@ describe Lstash::CLI do
     end
 
     context "without query" do
-      let(:args) { %w() }
+      let(:args) { %w[] }
       it "should print help message" do
         output = capture_stdout { Lstash::CLI.start(args) }
 
@@ -76,14 +74,14 @@ describe Lstash::CLI do
     end
 
     context "with anchor date" do
-      let(:args) { %w(count program:haproxy --from firstday --to today --anchor yesterday) }
+      let(:args) { %w[count program:haproxy --from firstday --to today --anchor yesterday] }
 
       it "should return correct count" do
-        es_client = double('es_client')
+        es_client = double("es_client")
 
         allow(Elasticsearch::Client).to receive(:new) { es_client }
 
-        expect(es_client).to receive(:count).exactly(31 * 24).times.and_return(count:100)
+        expect(es_client).to receive(:count).exactly(31 * 24).times.and_return(count: 100)
 
         output = capture_stdout { Lstash::CLI.start(args) }
         expect(output).to match("#{31 * 24 * 100}")
@@ -91,20 +89,18 @@ describe Lstash::CLI do
     end
 
     context "without anchor date" do
-      let(:args) { %w(count program:haproxy --from yesterday --to today) }
+      let(:args) { %w[count program:haproxy --from yesterday --to today] }
 
       it "should return correct count" do
-        es_client = double('es_client')
+        es_client = double("es_client")
 
         allow(Elasticsearch::Client).to receive(:new) { es_client }
 
-        expect(es_client).to receive(:count).exactly(24).times.and_return(count:100)
+        expect(es_client).to receive(:count).exactly(24).times.and_return(count: 100)
 
         output = capture_stdout { Lstash::CLI.start(args) }
         expect(output).to match("#{24 * 100}")
       end
     end
-
   end
-
 end

--- a/spec/lstash/cli_spec.rb
+++ b/spec/lstash/cli_spec.rb
@@ -74,7 +74,7 @@ describe Lstash::CLI do
     end
 
     context "with anchor date" do
-      let(:args) { %w[count program:haproxy --from firstday --to today --anchor yesterday] }
+      let(:args) { %w[count program:haproxy --from firstday --to today --anchor yesterday --no-wildcard] }
 
       it "should return correct count" do
         es_client = double("es_client")
@@ -90,7 +90,7 @@ describe Lstash::CLI do
     end
 
     context "without anchor date" do
-      let(:args) { %w[count program:haproxy --from yesterday --to today] }
+      let(:args) { %w[count program:haproxy --from yesterday --to today --no-wildcard] }
 
       it "should return correct count" do
         es_client = double("es_client")

--- a/spec/lstash/cli_spec.rb
+++ b/spec/lstash/cli_spec.rb
@@ -1,7 +1,7 @@
 require "spec_helper"
 require "lstash/cli"
 
-class Lstash::CLI < Thor
+class Lstash::CLI < Lstash::CLIBase
   def self.exit_on_failure?
     false
   end

--- a/spec/lstash/cli_spec.rb
+++ b/spec/lstash/cli_spec.rb
@@ -80,8 +80,9 @@ describe Lstash::CLI do
         es_client = double("es_client")
 
         allow(Elasticsearch::Client).to receive(:new) { es_client }
+        allow_any_instance_of(Lstash::Client).to receive(:validate_shards!).and_return(true)
 
-        expect(es_client).to receive(:count).exactly(31 * 24).times.and_return(count: 100)
+        expect(es_client).to receive(:count).exactly(31 * 24).times.and_return("count" => 100)
 
         output = capture_stdout { Lstash::CLI.start(args) }
         expect(output).to match("#{31 * 24 * 100}")
@@ -95,8 +96,9 @@ describe Lstash::CLI do
         es_client = double("es_client")
 
         allow(Elasticsearch::Client).to receive(:new) { es_client }
+        allow_any_instance_of(Lstash::Client).to receive(:validate_shards!).and_return(true)
 
-        expect(es_client).to receive(:count).exactly(24).times.and_return(count: 100)
+        expect(es_client).to receive(:count).exactly(24).times.and_return("count" => 100)
 
         output = capture_stdout { Lstash::CLI.start(args) }
         expect(output).to match("#{24 * 100}")

--- a/spec/lstash/cli_spec.rb
+++ b/spec/lstash/cli_spec.rb
@@ -85,7 +85,7 @@ describe Lstash::CLI do
         expect(es_client).to receive(:count).exactly(31 * 24).times.and_return("count" => 100)
 
         output = capture_stdout { Lstash::CLI.start(args) }
-        expect(output).to match("#{31 * 24 * 100}")
+        expect(output).to match((31 * 24 * 100).to_s)
       end
     end
 
@@ -101,7 +101,7 @@ describe Lstash::CLI do
         expect(es_client).to receive(:count).exactly(24).times.and_return("count" => 100)
 
         output = capture_stdout { Lstash::CLI.start(args) }
-        expect(output).to match("#{24 * 100}")
+        expect(output).to match((24 * 100).to_s)
       end
     end
   end

--- a/spec/lstash/client_spec.rb
+++ b/spec/lstash/client_spec.rb
@@ -3,7 +3,7 @@ require "lstash/client"
 
 describe Lstash::Client do
   let(:es_client) { double("es_client") }
-  subject { Lstash::Client.new(es_client) }
+  subject { Lstash::Client.new(es_client, wildcard: false) }
   before do
     allow(subject).to receive(:validate_shards!).and_return(true)
   end

--- a/spec/lstash/client_spec.rb
+++ b/spec/lstash/client_spec.rb
@@ -35,7 +35,7 @@ describe Lstash::Client do
       it "should return the messages matching the query" do
         query = Lstash::Query.new("*", from: Time.parse("2014-10-10 00:00"), to: Time.parse("2014-10-10 07:00"))
 
-        expect(es_client).to receive(:search).and_return(
+        allow(es_client).to receive(:search).and_return(
           hits(%w[1]),
           hits(%w[2 2]),
           hits(%w[3 3 3]),

--- a/spec/lstash/client_spec.rb
+++ b/spec/lstash/client_spec.rb
@@ -15,7 +15,7 @@ describe Lstash::Client do
   context "with query" do
     context "count" do
       it "should return number of messages matching query" do
-        query = Lstash::Query.new("*", from: Time.parse("2014-10-10 00:00"), to: Time.parse("2014-10-10 07:00"))
+        query = Lstash::Query.new("*", from: "2014-10-10 00:00", to: "2014-10-10 07:00")
 
         allow(es_client).to receive(:count).and_return(
           {"count" => 100},
@@ -33,7 +33,7 @@ describe Lstash::Client do
 
     context "grep" do
       it "should return the messages matching the query" do
-        query = Lstash::Query.new("*", from: Time.parse("2014-10-10 00:00"), to: Time.parse("2014-10-10 07:00"))
+        query = Lstash::Query.new("*", from: "2014-10-10 00:00", to: "2014-10-10 07:00")
 
         allow(es_client).to receive(:search).and_return(
           hits(%w[1]),

--- a/spec/lstash/client_spec.rb
+++ b/spec/lstash/client_spec.rb
@@ -54,7 +54,7 @@ describe Lstash::Client do
   def hits(messages)
     {
       hits: {
-        hits: messages.map { |m| {fields: {message: m}} }
+        hits: messages.map { |m| {_source: {message: m}} }
       }
     }
   end

--- a/spec/lstash/client_spec.rb
+++ b/spec/lstash/client_spec.rb
@@ -48,7 +48,7 @@ describe Lstash::Client do
         allow(es_client).to receive(:scroll).and_return(hits([]))
 
         expect(es_client).to receive(:clear_scroll).exactly(7).times
-        expect(subject.grep(query, 3600)).to eq 28
+        expect(subject.grep(query)).to eq 28
       end
     end
   end

--- a/spec/lstash/client_spec.rb
+++ b/spec/lstash/client_spec.rb
@@ -1,9 +1,8 @@
-require 'spec_helper'
-require 'lstash/client'
+require "spec_helper"
+require "lstash/client"
 
 describe Lstash::Client do
-
-  let(:es_client) { double('es_client') }
+  let(:es_client) { double("es_client") }
   subject { Lstash::Client.new(es_client) }
 
   it "should initialize properly" do
@@ -11,20 +10,18 @@ describe Lstash::Client do
   end
 
   context "with query" do
-
     context "count" do
       it "should return number of messages matching query" do
-
         query = Lstash::Query.new("*", from: Time.parse("2014-10-10 00:00"), to: Time.parse("2014-10-10 07:00"))
 
         allow(es_client).to receive(:count).and_return(
-          { 'count' => 100 },
-          { 'count' => 200 },
-          { 'count' => 300 },
-          { 'count' => 400 },
-          { 'count' => 500 },
-          { 'count' => 600 },
-          { 'count' => 700 }
+          {"count" => 100},
+          {"count" => 200},
+          {"count" => 300},
+          {"count" => 400},
+          {"count" => 500},
+          {"count" => 600},
+          {"count" => 700}
         )
 
         expect(subject.count(query)).to eq 2800
@@ -33,17 +30,16 @@ describe Lstash::Client do
 
     context "grep" do
       it "should return the messages matching the query" do
-
         query = Lstash::Query.new("*", from: Time.parse("2014-10-10 00:00"), to: Time.parse("2014-10-10 07:00"))
-      
+
         expect(es_client).to receive(:search).and_return(
-          hits(%w(1)),
-          hits(%w(2 2)),
-          hits(%w(3 3 3)),
-          hits(%w(4 4 4 4)),
-          hits(%w(5 5 5 5 5)),
-          hits(%w(6 6 6 6 6 6)),
-          hits(%w(7 7 7 7 7 7 7))
+          hits(%w[1]),
+          hits(%w[2 2]),
+          hits(%w[3 3 3]),
+          hits(%w[4 4 4 4]),
+          hits(%w[5 5 5 5 5]),
+          hits(%w[6 6 6 6 6 6]),
+          hits(%w[7 7 7 7 7 7 7])
         )
 
         allow(es_client).to receive(:scroll).and_return(hits([]))
@@ -53,15 +49,13 @@ describe Lstash::Client do
         expect(subject.grep(query, 3600)).to eq 28
       end
     end
-
   end
 
   def hits(messages)
     {
       hits: {
-        hits: messages.map { |m| { fields: { message: m }}}
+        hits: messages.map { |m| {fields: {message: m}} }
       }
     }
   end
-
 end

--- a/spec/lstash/client_spec.rb
+++ b/spec/lstash/client_spec.rb
@@ -47,8 +47,7 @@ describe Lstash::Client do
 
         allow(es_client).to receive(:scroll).and_return(hits([]))
 
-        allow(es_client).to receive(:clear_scroll)
-
+        expect(es_client).to receive(:clear_scroll).exactly(7).times
         expect(subject.grep(query, 3600)).to eq 28
       end
     end

--- a/spec/lstash/client_spec.rb
+++ b/spec/lstash/client_spec.rb
@@ -4,6 +4,9 @@ require "lstash/client"
 describe Lstash::Client do
   let(:es_client) { double("es_client") }
   subject { Lstash::Client.new(es_client) }
+  before do
+    allow(subject).to receive(:validate_shards!).and_return(true)
+  end
 
   it "should initialize properly" do
     expect(subject).not_to be nil
@@ -53,8 +56,8 @@ describe Lstash::Client do
 
   def hits(messages)
     {
-      hits: {
-        hits: messages.map { |m| {_source: {message: m}} }
+      "hits" => {
+        "hits" => messages.map { |m| {"_source" => {"message" => m}} }
       }
     }
   end

--- a/spec/lstash/query_spec.rb
+++ b/spec/lstash/query_spec.rb
@@ -9,7 +9,7 @@ describe Lstash::Query do
 
     subject { Lstash::Query.new(query_string, options) }
 
-    before { Timecop.freeze(Time.parse(time)) }
+    before { Timecop.freeze(time) }
     after { Timecop.return }
 
     it { should_not be nil }

--- a/spec/lstash/query_spec.rb
+++ b/spec/lstash/query_spec.rb
@@ -17,8 +17,8 @@ describe Lstash::Query do
     #   expect(subject).not_to be nil
     # end
 
-    its("from") { should eq Time.parse("2014-08-03 00:00:00 +0200") }
-    its("to") { should eq Time.parse("2014-08-03 15:54:33 +0200") }
+    its("from") { should eq Time.parse("2014-08-02 00:00:00 +0200") }
+    its("to") { should eq Time.parse("2014-08-03 00:00:00 +0200") }
 
     # its(:date_range) { should eq (Date.parse('2014-08-02')..Date.parse('2014-08-03')) }
 
@@ -86,7 +86,7 @@ describe Lstash::Query do
       context "date range" do
         let(:options) { {from: "firstday", anchor: "yesterday"} }
         its("from") { should eq Time.parse("2014-08-01 00:00:00 +0200") }
-        its("to") { should eq Time.parse("2014-08-03 15:54:33 +0200") }
+        its("to") { should eq Time.parse("2014-08-03 00:00:00 +0200") }
       end
 
       context "each_period" do
@@ -171,7 +171,7 @@ describe Lstash::Query do
                 }
               ],
               filter: {
-                range: {"@timestamp" => {gte: 1407016800000, lt: 1407074073000}}
+                range: {"@timestamp" => {gte: 1406930400000, lt: 1407016800000}}
               }
             }
           },
@@ -196,7 +196,7 @@ describe Lstash::Query do
       let(:options) { {anchor: "yesterday", from: "firstday"} }
 
       its("from") { should eq Time.parse("2014-07-01 00:00:00 +0200") }
-      its("to") { should eq Time.parse("2014-08-01 12:53:03 +0200") }
+      its("to") { should eq Time.parse("2014-08-01 00:00:00 +0200") }
     end
 
     context "from 'firstday' with default 'today' anchor" do

--- a/spec/lstash/query_spec.rb
+++ b/spec/lstash/query_spec.rb
@@ -17,8 +17,8 @@ describe Lstash::Query do
     #   expect(subject).not_to be nil
     # end
 
-    its("from") { should eq Time.parse("2014-08-03 00:00:00.000000000 +0200") }
-    its("to") { should eq Time.parse("2014-08-03 15:54:33.000000000 +0200") }
+    its("from") { should eq Time.parse("2014-08-03 00:00:00 +0200") }
+    its("to") { should eq Time.parse("2014-08-03 15:54:33 +0200") }
 
     # its(:date_range) { should eq (Date.parse('2014-08-02')..Date.parse('2014-08-03')) }
 
@@ -36,57 +36,57 @@ describe Lstash::Query do
 
     context "from 'yesterday'" do
       let(:options) { {from: "yesterday"} }
-      its("from") { should eq Time.parse("2014-08-02 00:00:00.000000000 +0200") }
+      its("from") { should eq Time.parse("2014-08-02 00:00:00 +0200") }
     end
 
     context "from 'today'" do
       let(:options) { {from: "today"} }
-      its("from") { should eq Time.parse("2014-08-03 00:00:00.000000000 +0200") }
+      its("from") { should eq Time.parse("2014-08-03 00:00:00 +0200") }
     end
 
     context "from 'now'" do
       let(:options) { {from: "now"} }
-      its("from") { should eq Time.parse("2014-08-03 15:54:33.000000000 +0200") }
+      its("from") { should eq Time.parse("2014-08-03 15:54:33 +0200") }
     end
 
     context "to 'yesterday'" do
       let(:options) { {to: "yesterday"} }
-      its("to") { should eq Time.parse("2014-08-02 00:00:00.000000000 +0200") }
+      its("to") { should eq Time.parse("2014-08-02 00:00:00 +0200") }
     end
 
     context "to 'today'" do
       let(:options) { {to: "today"} }
-      its("to") { should eq Time.parse("2014-08-03 00:00:00.000000000 +0200") }
+      its("to") { should eq Time.parse("2014-08-03 00:00:00 +0200") }
     end
 
     context "to 'now'" do
       let(:options) { {to: "now"} }
-      its("to") { should eq Time.parse("2014-08-03 15:54:33.000000000 +0200") }
+      its("to") { should eq Time.parse("2014-08-03 15:54:33 +0200") }
     end
 
     context "from 'firstday'" do
       let(:options) { {from: "firstday"} }
-      its("from") { should eq Time.parse("2014-08-01 00:00:00.000000000 +0200") }
+      its("from") { should eq Time.parse("2014-08-01 00:00:00 +0200") }
 
       context "anchor 'yesterday'" do
         let(:anchor) { "yesterday" }
-        its("from") { should eq Time.parse("2014-08-01 00:00:00.000000000 +0200") }
+        its("from") { should eq Time.parse("2014-08-01 00:00:00 +0200") }
       end
 
       context "anchor 'today'" do
         let(:anchor) { "today" }
-        its("from") { should eq Time.parse("2014-08-01 00:00:00.000000000 +0200") }
+        its("from") { should eq Time.parse("2014-08-01 00:00:00 +0200") }
       end
 
       context "anchor '2014-07-17'" do
         let(:options) { {from: "firstday", anchor: "2014-07-17"} }
-        its("from") { should eq Time.parse("2014-07-01 00:00:00.000000000 +0200") }
+        its("from") { should eq Time.parse("2014-07-01 00:00:00 +0200") }
       end
 
       context "date range" do
         let(:options) { {from: "firstday", anchor: "yesterday"} }
-        its("from") { should eq Time.parse("2014-08-01 00:00:00.000000000 +0200") }
-        its("to") { should eq Time.parse("2014-08-03 15:54:33.000000000 +0200") }
+        its("from") { should eq Time.parse("2014-08-01 00:00:00 +0200") }
+        its("to") { should eq Time.parse("2014-08-03 15:54:33 +0200") }
       end
 
       context "each_period" do
@@ -195,15 +195,15 @@ describe Lstash::Query do
     context "from 'firstday' with 'yesterday' anchor" do
       let(:options) { {anchor: "yesterday", from: "firstday"} }
 
-      its("from") { should eq Time.parse("2014-07-01 00:00:00.000000000 +0200") }
-      its("to") { should eq Time.parse("2014-08-01 12:53:03.000000000 +0200") }
+      its("from") { should eq Time.parse("2014-07-01 00:00:00 +0200") }
+      its("to") { should eq Time.parse("2014-08-01 12:53:03 +0200") }
     end
 
     context "from 'firstday' with default 'today' anchor" do
       let(:options) { {from: "firstday", to: "now"} }
 
-      its("from") { should eq Time.parse("2014-08-01 00:00:00.000000000 +0200") }
-      its("to") { should eq Time.parse("2014-08-01 12:53:03.000000000 +0200") }
+      its("from") { should eq Time.parse("2014-08-01 00:00:00 +0200") }
+      its("to") { should eq Time.parse("2014-08-01 12:53:03 +0200") }
     end
   end
 end

--- a/spec/lstash/query_spec.rb
+++ b/spec/lstash/query_spec.rb
@@ -162,11 +162,19 @@ describe Lstash::Query do
       it "should produce the correct elasticsearch search request attributes" do
         expect(subject.search(0, 10)).to eq({
           sort: [{"@timestamp" => {order: "asc"}}],
-          fields: %w[message],
-          query: {filtered: {
-            query: {bool: {should: [{query_string: {query: "*"}}]}},
-            filter: {bool: {must: [{range: {"@timestamp" => {gte: 1407016800000, lt: 1407074073000}}}]}}
-          }},
+          _source: %w[message],
+          query: {
+            bool: {
+              must: [
+                {
+                  query_string: {query: "*"}
+                }
+              ],
+              filter: {
+                range: {"@timestamp" => {gte: 1407016800000, lt: 1407074073000}}
+              }
+            }
+          },
           from: 0,
           size: 10
         })

--- a/spec/lstash/query_spec.rb
+++ b/spec/lstash/query_spec.rb
@@ -1,98 +1,96 @@
-require 'spec_helper'
-require 'lstash/query'
+require "spec_helper"
+require "lstash/query"
 
 describe Lstash::Query do
-
   context "running on 2014-08-03" do
-    let(:time)  { '2014-08-03 15:54:33' }
+    let(:time) { "2014-08-03 15:54:33" }
     let(:query_string) { nil }
     let(:options) { {} }
 
     subject { Lstash::Query.new(query_string, options) }
 
     before { Timecop.freeze(Time.parse(time)) }
-    after  { Timecop.return }
+    after { Timecop.return }
 
     it { should_not be nil }
     # it "should initialize properly" do
     #   expect(subject).not_to be nil
     # end
 
-    its('from') { should eq Time.parse('2014-08-03 00:00:00.000000000 +0200') }
-    its('to')   { should eq Time.parse('2014-08-03 15:54:33.000000000 +0200') }
+    its("from") { should eq Time.parse("2014-08-03 00:00:00.000000000 +0200") }
+    its("to") { should eq Time.parse("2014-08-03 15:54:33.000000000 +0200") }
 
     # its(:date_range) { should eq (Date.parse('2014-08-02')..Date.parse('2014-08-03')) }
 
     # its(:indices) { should eq [ "logstash-2014.08.02", "logstash-2014.08.03" ] }
 
     context "with specific query" do
-      let(:query_string) { 'program:haproxy' }
+      let(:query_string) { "program:haproxy" }
       its(:query_string) { should eq query_string }
     end
 
     context "without query" do
       let(:query_string) { nil }
-      its(:query_string) { should eql '*' }
+      its(:query_string) { should eql "*" }
     end
 
     context "from 'yesterday'" do
-      let(:options) { { from: 'yesterday' }}
-      its('from') { should eq Time.parse('2014-08-02 00:00:00.000000000 +0200') }
+      let(:options) { {from: "yesterday"} }
+      its("from") { should eq Time.parse("2014-08-02 00:00:00.000000000 +0200") }
     end
 
     context "from 'today'" do
-      let(:options) { { from: 'today' }}
-      its('from') { should eq Time.parse('2014-08-03 00:00:00.000000000 +0200') }
+      let(:options) { {from: "today"} }
+      its("from") { should eq Time.parse("2014-08-03 00:00:00.000000000 +0200") }
     end
 
     context "from 'now'" do
-      let(:options) { { from: 'now' }}
-      its('from') { should eq Time.parse('2014-08-03 15:54:33.000000000 +0200') }
+      let(:options) { {from: "now"} }
+      its("from") { should eq Time.parse("2014-08-03 15:54:33.000000000 +0200") }
     end
 
     context "to 'yesterday'" do
-      let(:options) { { to: 'yesterday' }}
-      its('to') { should eq Time.parse('2014-08-02 00:00:00.000000000 +0200') }
+      let(:options) { {to: "yesterday"} }
+      its("to") { should eq Time.parse("2014-08-02 00:00:00.000000000 +0200") }
     end
 
     context "to 'today'" do
-      let(:options) { { to: 'today' }}
-      its('to') { should eq Time.parse('2014-08-03 00:00:00.000000000 +0200') }
+      let(:options) { {to: "today"} }
+      its("to") { should eq Time.parse("2014-08-03 00:00:00.000000000 +0200") }
     end
 
     context "to 'now'" do
-      let(:options) { { to: 'now' }}
-      its('to') { should eq Time.parse('2014-08-03 15:54:33.000000000 +0200') }
+      let(:options) { {to: "now"} }
+      its("to") { should eq Time.parse("2014-08-03 15:54:33.000000000 +0200") }
     end
 
     context "from 'firstday'" do
-
-      let(:options) { { from: 'firstday' } }
-      its('from') { should eq Time.parse('2014-08-01 00:00:00.000000000 +0200') }
+      let(:options) { {from: "firstday"} }
+      its("from") { should eq Time.parse("2014-08-01 00:00:00.000000000 +0200") }
 
       context "anchor 'yesterday'" do
-        let(:anchor) { 'yesterday' }
-        its('from') { should eq Time.parse('2014-08-01 00:00:00.000000000 +0200') }
+        let(:anchor) { "yesterday" }
+        its("from") { should eq Time.parse("2014-08-01 00:00:00.000000000 +0200") }
       end
 
       context "anchor 'today'" do
-        let(:anchor) { 'today' }
-        its('from') { should eq Time.parse('2014-08-01 00:00:00.000000000 +0200') }
+        let(:anchor) { "today" }
+        its("from") { should eq Time.parse("2014-08-01 00:00:00.000000000 +0200") }
       end
 
       context "anchor '2014-07-17'" do
-        let(:options) { { from: 'firstday', anchor: '2014-07-17' } }
-        its('from') { should eq Time.parse('2014-07-01 00:00:00.000000000 +0200') }
+        let(:options) { {from: "firstday", anchor: "2014-07-17"} }
+        its("from") { should eq Time.parse("2014-07-01 00:00:00.000000000 +0200") }
       end
 
       context "date range" do
-        let(:options) { { from: 'firstday', anchor: 'yesterday' } }
-        its('from') { should eq Time.parse('2014-08-01 00:00:00.000000000 +0200') }
-        its('to')   { should eq Time.parse('2014-08-03 15:54:33.000000000 +0200') }
+        let(:options) { {from: "firstday", anchor: "yesterday"} }
+        its("from") { should eq Time.parse("2014-08-01 00:00:00.000000000 +0200") }
+        its("to") { should eq Time.parse("2014-08-03 15:54:33.000000000 +0200") }
       end
 
       context "each_period" do
-        let(:options) { { from: 'firstday', anchor: 'yesterday', to: 'today' } }
+        let(:options) { {from: "firstday", anchor: "yesterday", to: "today"} }
         it "should iterate over range by hour" do
           indices = []
           queries = []
@@ -100,13 +98,13 @@ describe Lstash::Query do
             indices << index
             queries << query
           end
-          expect(indices.count).to eq ((subject.to - subject.from)/3600).round
-          expect(indices.uniq).to eq %w(
+          expect(indices.count).to eq ((subject.to - subject.from) / 3600).round
+          expect(indices.uniq).to eq %w[
             logstash-2014.07.31
             logstash-2014.08.01
             logstash-2014.08.02
-          )
-          expect(queries.map(&:from).map(&:to_s)).to eq ([
+          ]
+          expect(queries.map(&:from).map(&:to_s)).to eq([
             "2014-07-31 22:00:00 UTC",
             "2014-07-31 23:00:00 UTC",
             "2014-08-01 00:00:00 UTC",
@@ -158,50 +156,46 @@ describe Lstash::Query do
           ])
         end
       end
-
     end
 
     context "search" do
       it "should produce the correct elasticsearch search request attributes" do
-        expect(subject.search(0, 10)).to eq ({
-          :sort => [{"@timestamp"=>{:order=>"asc"}}],
-          :fields => %w(message),
-          :query => {:filtered=>{
-            :query => { :bool => { :should => [ { :query_string => { :query=>"*" }}]}},
-            :filter=> { :bool => { :must   => [ { :range => { "@timestamp" => { :gte => 1407016800000, :lt => 1407074073000}}}]}}}},
-          :from => 0,
-          :size => 10
+        expect(subject.search(0, 10)).to eq({
+          sort: [{"@timestamp" => {order: "asc"}}],
+          fields: %w[message],
+          query: {filtered: {
+            query: {bool: {should: [{query_string: {query: "*"}}]}},
+            filter: {bool: {must: [{range: {"@timestamp" => {gte: 1407016800000, lt: 1407074073000}}}]}}
+          }},
+          from: 0,
+          size: 10
         })
       end
     end
-
   end
 
   context "running on 2014-08-01" do
-    let(:time)  { '2014-08-01 12:53:03' }
+    let(:time) { "2014-08-01 12:53:03" }
     let(:query_string) { nil }
     let(:options) { {} }
 
     subject { Lstash::Query.new(query_string, options) }
 
     before { Timecop.freeze(Time.parse(time)) }
-    after  { Timecop.return }
+    after { Timecop.return }
 
     context "from 'firstday' with 'yesterday' anchor" do
-      let(:options) { { anchor: 'yesterday', from: 'firstday' } }
+      let(:options) { {anchor: "yesterday", from: "firstday"} }
 
-        its('from') { should eq Time.parse('2014-07-01 00:00:00.000000000 +0200') }
-        its('to')   { should eq Time.parse('2014-08-01 12:53:03.000000000 +0200') }
+      its("from") { should eq Time.parse("2014-07-01 00:00:00.000000000 +0200") }
+      its("to") { should eq Time.parse("2014-08-01 12:53:03.000000000 +0200") }
     end
 
     context "from 'firstday' with default 'today' anchor" do
-      let(:options) { { from: 'firstday', to: 'now' } }
+      let(:options) { {from: "firstday", to: "now"} }
 
-        its('from') { should eq Time.parse('2014-08-01 00:00:00.000000000 +0200') }
-        its('to')   { should eq Time.parse('2014-08-01 12:53:03.000000000 +0200') }
+      its("from") { should eq Time.parse("2014-08-01 00:00:00.000000000 +0200") }
+      its("to") { should eq Time.parse("2014-08-01 12:53:03.000000000 +0200") }
     end
-
   end
-
 end
-

--- a/spec/lstash_spec.rb
+++ b/spec/lstash_spec.rb
@@ -1,8 +1,8 @@
-require 'spec_helper'
-require 'lstash/cli'
+require "spec_helper"
+require "lstash/cli"
 
 describe Lstash do
-  it 'should have a version number' do
+  it "should have a version number" do
     expect(Lstash::VERSION).not_to be nil
   end
 end

--- a/spec/spec_helper.rb
+++ b/spec/spec_helper.rb
@@ -10,6 +10,21 @@ ENV["TZ"] = "Europe/Amsterdam" # Test in a specific timezone.
 
 RSpec.configure do |config|
   config.order = "random"
+
+  # Suggestions taken from http://railscasts.com/episodes/413-fast-tests
+  #
+  # Focus on specific specs by tagging with `:focus`
+  # or use `fit` instead of `it`.
+  # ```ruby
+  # it "focus test", :focus do
+  # end
+  #
+  # fit "focus test" do
+  # end
+  # ```
+  config.alias_example_to :fit, focus: true
+  config.filter_run focus: true
+  config.run_all_when_everything_filtered = true
 end
 
 require "stringio"

--- a/spec/spec_helper.rb
+++ b/spec/spec_helper.rb
@@ -1,32 +1,32 @@
-$LOAD_PATH.unshift File.expand_path('../../lib', __FILE__)
-require 'lstash'
+$LOAD_PATH.unshift File.expand_path("../../lib", __FILE__)
+require "lstash"
 
-require 'rspec/its'
+require "rspec/its"
 
-require 'timecop'
+require "timecop"
 
-ENV['ES_URL'] = nil
-ENV['TZ'] = 'Europe/Amsterdam' # Test in a specific timezone.
+ENV["ES_URL"] = nil
+ENV["TZ"] = "Europe/Amsterdam" # Test in a specific timezone.
 
 RSpec.configure do |config|
-  config.order = 'random'
+  config.order = "random"
 end
 
-require 'stringio'
+require "stringio"
 
-def capture_stdout(&blk)
+def capture_stdout
   old = $stdout
   $stdout = fake = StringIO.new
-  blk.call
+  yield
   fake.string
 ensure
   $stdout = old
 end
 
-def capture_stderr(&blk)
+def capture_stderr
   old = $stderr
   $stderr = fake = StringIO.new
-  blk.call
+  yield
   fake.string
 ensure
   $stderr = old


### PR DESCRIPTION
Changes

* BREAKING CHANGE: default options changed
  * Default `--from today` changed to `--from yesterday`
  * Default `--to now` changed to `--to today`
  * This ensures that by default lstash counts or greps in yesterdays logging.
* Fixed bug which causes empty range (e.g. `--from today --to today`) to incorrectly return non-zero count and logging.
* Upgrade `elasticsearch` gem from version `~> 0.4` to `~> 7.17.7`.
* Update queries and field selectors to be compatible with Elasticsearch version 7.
* Increase scroll step size for `grep` from 2 minutes to 1 hour (current Elasticsearch can handle it).
* Add --wildcard / --no-wildcard option to use `logstash-*` wildcard instead of iterating over indices directly.
  * For the `count` command `--wildcard` is faster so that's the default for `count`.
  * For the `grep` command `--no-wildcard` is faster so that's the default for `grep`.
* Dockerize development and add GitHub action for testing.
* Moved repo from `kdgm/lstash` to `kdgm/lstash`.
* Rubocop fixes